### PR TITLE
docs: Correct version number, shorter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ job:
     deployments: read
   steps:
     - name: Get last active deployment
-      uses: go-fjords/get-active-deployment-action@v1
+      uses: go-fjords/get-active-deployment-action@v0
       id: get-deployment
       with:
         environment: production
@@ -58,7 +58,7 @@ jobs:
       deployments: read
     steps:
       - name: Get last active deployment
-        uses: go-fjords/get-active-deployment-action@v1
+        uses: go-fjords/get-active-deployment-action@v0
         id: get-deployment
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,5 @@
 name: 'Get Last Active Deployment Action'
-description: |
-  Find the (nth) last active deployment for a given GitHub environment.
-  The action will complete with empty outputs if no active deployments
-  are found. The action is useful for instance when you want to find the
-  SHA of the previous deployment to an environment so you can compute
-  the diff or commit history between the two deployments.
+description: Find the (nth) last active deployment for a given GitHub environment.
 author: 'Adventure Tech AS'
 
 # Define your inputs here.

--- a/example-workflows/get-previous-active-deployment.yml
+++ b/example-workflows/get-previous-active-deployment.yml
@@ -10,7 +10,7 @@ jobs:
       deployments: read
     steps:
       - name: Get previous active deployment
-        uses: go-fjords/get-active-deployment-action@v1
+        uses: go-fjords/get-active-deployment-action@v0
         id: get-deployment
         with:
           environment: ${{ github.event.deployment.environment }}


### PR DESCRIPTION
The descriptionc cannot be longer than 125 characters according to GitHub Marketplace rules, so shortened it down.

Fixed version number in examples in README.md and example workflows.